### PR TITLE
Refactor for RabbitMQ.Client 6.x, minor changes

### DIFF
--- a/src/Escendit.Orleans.Streaming.RabbitMQ/Configuration/RabbitClusterClientQueueConfigurator.cs
+++ b/src/Escendit.Orleans.Streaming.RabbitMQ/Configuration/RabbitClusterClientQueueConfigurator.cs
@@ -6,6 +6,7 @@ namespace Orleans.Hosting;
 using Configuration;
 using Escendit.Orleans.Streaming.RabbitMQ.Options;
 using Escendit.Orleans.Streaming.RabbitMQ.Queue;
+using Microsoft.Extensions.DependencyInjection;
 using Runtime;
 
 /// <summary>
@@ -35,7 +36,9 @@ internal class RabbitClusterClientQueueConfigurator : ClusterClientPersistentStr
             {
                 configure
                     .AddSingletonNamedService(name, DefaultQueueAdapterFactory.Create)
-                    .ConfigureNamedOptionForLogging<RabbitQueueOptions>(name);
+                    .ConfigureNamedOptionForLogging<RabbitQueueOptions>(name)
+                    .AddRabbitMq(name)
+                    .WithConnection();
             });
     }
 }

--- a/src/Escendit.Orleans.Streaming.RabbitMQ/Configuration/RabbitSiloQueueConfigurator.cs
+++ b/src/Escendit.Orleans.Streaming.RabbitMQ/Configuration/RabbitSiloQueueConfigurator.cs
@@ -31,7 +31,9 @@ internal class RabbitSiloQueueConfigurator : SiloPersistentStreamConfigurator
         {
             services
                 .AddSingletonNamedService(name, DefaultQueueAdapterFactory.Create)
-                .ConfigureNamedOptionForLogging<RabbitQueueOptions>(name);
+                .ConfigureNamedOptionForLogging<RabbitQueueOptions>(name)
+                .AddRabbitMq(name)
+                .WithConnection();
         });
     }
 }

--- a/src/Escendit.Orleans.Streaming.RabbitMQ/Core/NamingUtility.cs
+++ b/src/Escendit.Orleans.Streaming.RabbitMQ/Core/NamingUtility.cs
@@ -11,15 +11,29 @@ using global::Orleans.Streams;
 /// </summary>
 internal static class NamingUtility
 {
+    private const string Stream = "stream";
+    private const string Queue = "queue";
+
     /// <summary>
-    /// Create a Name for a Queue.
+    /// Create a Name for a Queue or an Exchange.
     /// </summary>
     /// <param name="clusterOptions">The cluster options.</param>
     /// <param name="queueId">The queue id.</param>
     /// <returns>The unique name for a queue or an exchange.</returns>
     public static string CreateNameForQueue(ClusterOptions clusterOptions, QueueId queueId)
     {
-        return $"queue-{clusterOptions.ClusterId}-{clusterOptions.ServiceId}-{queueId.ToString()}";
+        return CreateNameInternal(Queue, clusterOptions.ClusterId, clusterOptions.ServiceId, queueId.ToString());
+    }
+
+    /// <summary>
+    /// Create a Name for a Queue or an Exchange.
+    /// </summary>
+    /// <param name="clusterOptions">The cluster options.</param>
+    /// <param name="name">The exchange name.</param>
+    /// <returns>The unique name for an exchange.</returns>
+    public static string CreateNameForQueue(ClusterOptions clusterOptions, string name)
+    {
+        return CreateNameInternal(Queue, clusterOptions.ClusterId, clusterOptions.ServiceId, name);
     }
 
     /// <summary>
@@ -30,6 +44,11 @@ internal static class NamingUtility
     /// <returns>The unique name for a stream (queue).</returns>
     public static string CreateNameForStream(ClusterOptions clusterOptions, QueueId queueId)
     {
-        return $"stream-{clusterOptions.ClusterId}-{clusterOptions.ServiceId}-{queueId.ToString()}";
+        return CreateNameInternal(Stream, clusterOptions.ClusterId, clusterOptions.ServiceId, queueId.ToString());
+    }
+
+    private static string CreateNameInternal(string type, string clusterId, string serviceId, string name)
+    {
+        return $"{type}-{clusterId}-{serviceId}-{name}";
     }
 }

--- a/src/Escendit.Orleans.Streaming.RabbitMQ/Escendit.Orleans.Streaming.RabbitMQ.csproj
+++ b/src/Escendit.Orleans.Streaming.RabbitMQ/Escendit.Orleans.Streaming.RabbitMQ.csproj
@@ -7,8 +7,8 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.1.2" />
         <PackageReference Include="Microsoft.Orleans.Streaming" Version="7.1.2" />
-        <PackageReference Include="RabbitMQ.Client" Version="5.2.0" />
-        <PackageReference Include="RabbitMQ.Stream.Client" Version="1.3.0" />
+        <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
+        <PackageReference Include="RabbitMQ.Stream.Client" Version="1.4.1" />
     </ItemGroup>
     <ItemGroup>
         <None Pack="true" PackagePath="" Include="$(SolutionDir)/README.md" />

--- a/src/Escendit.Orleans.Streaming.RabbitMQ/Hosting/IRabbitConnectionFactoryBuilder.cs
+++ b/src/Escendit.Orleans.Streaming.RabbitMQ/Hosting/IRabbitConnectionFactoryBuilder.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Escendit Ltd. All Rights Reserved.
+// Licensed under the MIT. See LICENSE.txt file in the solution root for full license information.
+
+namespace Escendit.Orleans.Streaming.RabbitMQ.Hosting;
+
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Rabbit Connection Factory Builder.
+/// </summary>
+public interface IRabbitConnectionFactoryBuilder
+{
+    /// <summary>
+    /// Gets the service collection.
+    /// </summary>
+    /// <value>The services.</value>
+    IServiceCollection Services { get; }
+
+    /// <summary>
+    /// Gets the name.
+    /// </summary>
+    /// <value>The name.</value>
+    string Name { get; }
+}

--- a/src/Escendit.Orleans.Streaming.RabbitMQ/Hosting/RabbitConnectionFactoryBuilder.cs
+++ b/src/Escendit.Orleans.Streaming.RabbitMQ/Hosting/RabbitConnectionFactoryBuilder.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Escendit Ltd. All Rights Reserved.
+// Licensed under the MIT. See LICENSE.txt file in the solution root for full license information.
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+using Escendit.Orleans.Streaming.RabbitMQ.Hosting;
+
+/// <summary>
+/// Rabbit Connection Factory Builder.
+/// </summary>
+public class RabbitConnectionFactoryBuilder : IRabbitConnectionFactoryBuilder
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RabbitConnectionFactoryBuilder"/> class.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="name">The name.</param>
+    internal RabbitConnectionFactoryBuilder(IServiceCollection services, string name)
+    {
+        Services = services;
+        Name = name;
+    }
+
+    /// <inheritdoc />
+    public IServiceCollection Services { get; }
+
+    /// <inheritdoc />
+    public string Name { get; }
+}

--- a/src/Escendit.Orleans.Streaming.RabbitMQ/Hosting/ServiceCollectionExtensions.cs
+++ b/src/Escendit.Orleans.Streaming.RabbitMQ/Hosting/ServiceCollectionExtensions.cs
@@ -1,0 +1,178 @@
+﻿// Copyright (c) Escendit Ltd. All Rights Reserved.
+// Licensed under the MIT. See LICENSE.txt file in the solution root for full license information.
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+using System.Diagnostics.CodeAnalysis;
+using Escendit.Orleans.Streaming.RabbitMQ.Hosting;
+using Escendit.Orleans.Streaming.RabbitMQ.Options;
+using Options;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using RabbitMQ.Client;
+
+/// <summary>
+/// Service Collection Extensions.
+/// </summary>
+[DynamicallyAccessedMembers(
+    DynamicallyAccessedMemberTypes.All)]
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Add Named Rabbit MQ.
+    /// </summary>
+    /// <param name="services">The initial service collection.</param>
+    /// <param name="name">The name.</param>
+    /// <returns>The updated rabbit mq connection factory builder.</returns>
+    public static IRabbitConnectionFactoryBuilder AddRabbitMq(this IServiceCollection services, string name)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(name);
+
+        services
+            .AddRabbitNamedConnectionFactory(name);
+
+        return new RabbitConnectionFactoryBuilder(services, name);
+    }
+
+    /// <summary>
+    /// Add Named Rabbit MQ.
+    /// </summary>
+    /// <param name="services">The initial service collection.</param>
+    /// <param name="name">The name.</param>
+    /// <param name="options">The options.</param>
+    /// <returns>The updated rabbit mq connection factory builder.</returns>
+    public static IRabbitConnectionFactoryBuilder AddRabbitMq(
+        this IServiceCollection services,
+        string name,
+        Action<RabbitQueueOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(options);
+
+        services
+            .AddRabbitMq(name, configure =>
+            {
+                configure.Configure(options);
+            });
+
+        return new RabbitConnectionFactoryBuilder(services, name);
+    }
+
+    /// <summary>
+    /// Add Named Rabbit MQ.
+    /// </summary>
+    /// <param name="services">The initial service collection.</param>
+    /// <param name="name">The name.</param>
+    /// <param name="configureOptions">The configure options.</param>
+    /// <returns>The updated rabbit mq connection factory builder.</returns>
+    public static IRabbitConnectionFactoryBuilder AddRabbitMq(
+        this IServiceCollection services,
+        string name,
+        Action<OptionsBuilder<RabbitQueueOptions>> configureOptions)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        configureOptions
+            .Invoke(services.AddOptions<RabbitQueueOptions>(name));
+
+        services
+            .ConfigureNamedOptionForLogging<RabbitQueueOptions>(name)
+            .AddRabbitNamedConnectionFactory(name);
+        return new RabbitConnectionFactoryBuilder(services, name);
+    }
+
+    /// <summary>
+    /// Use with single connection.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    public static void WithConnection(this IRabbitConnectionFactoryBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder
+            .Services
+            .AddRabbitNamedConnection(builder.Name);
+    }
+
+    /// <summary>
+    /// Add Rabbit MQ Named Connection Factory.
+    /// </summary>
+    /// <param name="services">The initial service collection.</param>
+    /// <param name="name">The name.</param>
+    /// <returns>The updated service collection.</returns>
+    private static IServiceCollection AddRabbitNamedConnectionFactory(this IServiceCollection services, string name)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(name);
+
+        return services
+            .AddSingletonNamedService<IConnectionFactory>(
+                name,
+                (serviceProvider, providerName) =>
+                {
+                    var options = serviceProvider.GetOptionsByName<RabbitQueueOptions>(providerName);
+                    return new ConnectionFactory
+                    {
+                        Password = options.Password,
+                        UserName = options.UserName,
+                        VirtualHost = options.VirtualHost,
+                        UseBackgroundThreadsForIO = true,
+                        Ssl = options.SslOptions is null
+                            ? null
+                            : new SslOption
+                            {
+                                AcceptablePolicyErrors = options.SslOptions.AcceptablePolicyErrors,
+                                Certs = options.SslOptions.Certificates,
+                                Enabled = options.SslOptions.Enabled,
+                                Version = options.SslOptions.Version,
+                                CertPassphrase = options.SslOptions.CertPassphrase,
+                                CertPath = options.SslOptions.CertPath,
+                                ServerName = options.SslOptions.ServerName,
+                                CertificateSelectionCallback = options.SslOptions.CertificateSelectionCallback,
+                                CertificateValidationCallback = options.SslOptions.CertificateValidationCallback,
+                            },
+                    };
+                });
+    }
+
+    /// <summary>
+    /// Add Rabbit MQ Named Connection.
+    /// </summary>
+    /// <param name="services">The initial service collection.</param>
+    /// <param name="name">The name.</param>
+    /// <returns>The updated service collection.</returns>
+    private static IServiceCollection AddRabbitNamedConnection(this IServiceCollection services, string name)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(name);
+
+        return services
+            .AddSingletonNamedService<IConnection>(name, (serviceProvider, providerName) =>
+            {
+                var options = serviceProvider.GetOptionsByName<RabbitQueueOptions>(providerName);
+                var clusterOptions = serviceProvider.GetRequiredService<IOptions<ClusterOptions>>();
+                var connectionFactory = serviceProvider.GetRequiredServiceByName<IConnectionFactory>(providerName);
+                var clusterId = clusterOptions.Value.ClusterId;
+                var serviceId = clusterOptions.Value.ServiceId;
+
+                return Task
+                    .Run(() =>
+                        connectionFactory
+                            .CreateConnection(
+                                options
+                                    .Endpoints
+                                    .Select(endpoint =>
+                                        new AmqpTcpEndpoint(
+                                            endpoint.HostName,
+                                            endpoint.Port ?? options.DefaultPort))
+                                    .ToList(),
+                                $"queue-client-{clusterId}-{serviceId}-{name}"))
+                    .ConfigureAwait(false)
+                    .GetAwaiter()
+                    .GetResult();
+            });
+    }
+}

--- a/src/Escendit.Orleans.Streaming.RabbitMQ/Options/RabbitQueueOptions.cs
+++ b/src/Escendit.Orleans.Streaming.RabbitMQ/Options/RabbitQueueOptions.cs
@@ -3,30 +3,33 @@
 
 namespace Escendit.Orleans.Streaming.RabbitMQ.Options;
 
+using System.Diagnostics.CodeAnalysis;
 using global::RabbitMQ.Client;
 
 /// <summary>
 /// Rabbit MQ Stream Provider Options.
 /// </summary>
+[DynamicallyAccessedMembers(
+    DynamicallyAccessedMemberTypes.PublicProperties)]
 public record RabbitQueueOptions : RabbitOptionsBase
 {
     /// <summary>
-    /// Default Routing Key.
+    /// Default Exchange Key.
     /// </summary>
-    private const string DefaultRoutingKey = "queue";
+    private const string DefaultExchangekey = "exchange";
 
     /// <summary>
     /// Gets or sets the exchange type.
     /// </summary>
     /// <para>The default is <see cref="ExchangeType.Direct"/>.</para>
     /// <value>The exchange type.</value>
-    public string QueueType { get; set; } = ExchangeType.Direct;
+    public string Type { get; set; } = ExchangeType.Topic;
 
     /// <summary>
-    /// Gets or sets the routing key.
+    /// Gets or sets the exchange name.
     /// </summary>
-    /// <value>The routing key.</value>
-    public string RoutingKey { get; set; } = DefaultRoutingKey;
+    /// <value>The exchange name.</value>
+    public string Name { get; set; } = DefaultExchangekey;
 
     /// <summary>
     /// Gets or sets a value indicating whether the queue is durable.
@@ -41,16 +44,19 @@ public record RabbitQueueOptions : RabbitOptionsBase
     public bool IsExclusive { get; set; }
 
     /// <summary>
-    /// Get Default Port.
+    /// Gets the default Port.
     /// </summary>
-    /// <returns>The port.</returns>
-    public int GetDefaultPort()
+    /// <value>The default port.</value>
+    public int DefaultPort
     {
-        if (SslOptions is null)
+        get
         {
-            return 5672;
-        }
+            if (SslOptions is null)
+            {
+                return 5672;
+            }
 
-        return SslOptions.Enabled ? 5671 : 5672;
+            return SslOptions.Enabled ? 5671 : 5672;
+        }
     }
 }

--- a/test/Escendit.Orleans.Streaming.RabbitMQ.Tests/Configuration/TestSiloConfigurator.cs
+++ b/test/Escendit.Orleans.Streaming.RabbitMQ.Tests/Configuration/TestSiloConfigurator.cs
@@ -3,8 +3,10 @@
 
 namespace Escendit.Orleans.Streaming.RabbitMQ.Tests.Configuration;
 
-using global::Orleans.TestingHost;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using global::Orleans.TestingHost;
+using Options;
 
 /// <summary>
 /// Test Silo Configurator.
@@ -28,5 +30,17 @@ public class TestSiloConfigurator : ISiloConfigurator
         siloBuilder
             .AddMemoryGrainStorageAsDefault()
             .AddLogStorageBasedLogConsistencyProviderAsDefault();
+
+        siloBuilder
+            .Services
+            .AddRabbitMq("custom", options =>
+            {
+                options.Endpoints.Add(new RabbitEndpoint { HostName = "localhost", Port = 5672 });
+                options.UserName = "test";
+                options.Password = "test";
+                options.VirtualHost = "testing";
+                options.ClientProvidedName = "Custom-Connection";
+            })
+            .WithConnection();
     }
 }

--- a/test/Escendit.Orleans.Streaming.RabbitMQ.Tests/Escendit.Orleans.Streaming.RabbitMQ.Tests.csproj
+++ b/test/Escendit.Orleans.Streaming.RabbitMQ.Tests/Escendit.Orleans.Streaming.RabbitMQ.Tests.csproj
@@ -4,8 +4,6 @@
       <PackageReference Include="Microsoft.Orleans.EventSourcing" Version="7.1.2" />
       <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.1.2" />
       <PackageReference Include="Microsoft.Orleans.TestingHost" Version="7.1.2" />
-      <PackageReference Include="RabbitMQ.Client" Version="5.2.0" />
-      <PackageReference Include="RabbitMQ.Stream.Client" Version="1.3.0" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\..\src\Escendit.Orleans.Streaming.RabbitMQ\Escendit.Orleans.Streaming.RabbitMQ.csproj" />

--- a/test/Escendit.Orleans.Streaming.RabbitMQ.Tests/QueueClientTests.cs
+++ b/test/Escendit.Orleans.Streaming.RabbitMQ.Tests/QueueClientTests.cs
@@ -27,6 +27,7 @@ public class QueueClientTests
             VirtualHost = "testing",
             UserName = "test",
             Password = "test",
+            ClientProvidedName = "queue-client-test",
         };
 
         var connection = connectionFactory.CreateConnection();

--- a/test/Escendit.Orleans.Streaming.RabbitMQ.Tests/StreamClientTests.cs
+++ b/test/Escendit.Orleans.Streaming.RabbitMQ.Tests/StreamClientTests.cs
@@ -41,6 +41,7 @@ public class StreamClientTests
             UserName = "test",
             Password = "test",
             VirtualHost = "testing",
+            ClientProvidedName = "stream-client-test",
         });
 
         await streamSystem.CreateStream(new StreamSpec("stream.test")


### PR DESCRIPTION
- Version upgrade for Classic RabbitMQ Client which needed Refactoring and optimization of Factories, Connections, and Channels.
- Version bump for RabbitMQ.Stream.Client
- Possibility to register RabbitMQ Connection to use without Streaming
